### PR TITLE
Bump default PgBouncer version to 1.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM alpine:3.8 AS builder
 
 ARG build_tag=pgbouncer_1_10_0
 
+RUN wget https://github.com/jgm/pandoc/releases/download/2.7.3/pandoc-2.7.3-linux.tar.gz
+RUN tar xvzf pandoc-2.7.3-linux.tar.gz --strip-components 1 -C /usr/local
+
 RUN apk --no-cache add make pkgconfig autoconf automake libtool py-docutils git gcc g++ libevent-dev openssl-dev c-ares-dev ca-certificates
 RUN git clone --branch ${build_tag} --recurse-submodules -j8 https://github.com/pgbouncer/pgbouncer.git
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.8 AS builder
 
-ARG build_tag=pgbouncer_1_9_0
+ARG build_tag=pgbouncer_1_10_0
 
 RUN apk --no-cache add make pkgconfig autoconf automake libtool py-docutils git gcc g++ libevent-dev openssl-dev c-ares-dev ca-certificates
 RUN git clone --branch ${build_tag} --recurse-submodules -j8 https://github.com/pgbouncer/pgbouncer.git


### PR DESCRIPTION
Heya,

This PR should bump the default pgbouncer version to the 1.10 release in July when building without args. 

I'm not sure if it also addresses the problems you had with OpenSSL. Maybe it helps :)

Thanks again! 